### PR TITLE
Embedding Support

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,3 +2,7 @@ from .users import *
 from .github import *
 from .resume import *
 #app.run(port=6000, debug=True, use_reloader=True)
+
+"""
+The text in each row of user_to_project will be combined to create a single column. Each project will be "<column_name>: <str(value)>" concatenated into a single string. Use gemini embeddings (https://ai.google.dev/gemini-api/docs/embeddings), and follow this: https://supabase.com/docs/guides/ai/semantic-search#semantic-search-in-postgres (try gte-small as well). Vectors are stored alongside the content
+"""

--- a/backend/app.py
+++ b/backend/app.py
@@ -2,7 +2,3 @@ from .users import *
 from .github import *
 from .resume import *
 #app.run(port=6000, debug=True, use_reloader=True)
-
-"""
-The text in each row of user_to_project will be combined to create a single column. Each project will be "<column_name>: <str(value)>" concatenated into a single string. Use gemini embeddings (https://ai.google.dev/gemini-api/docs/embeddings), and follow this: https://supabase.com/docs/guides/ai/semantic-search#semantic-search-in-postgres (try gte-small as well). Vectors are stored alongside the content
-"""

--- a/backend/github.py
+++ b/backend/github.py
@@ -1,35 +1,48 @@
 from .utils import *
 from github import Github, Auth
 from github.GithubException import UnknownObjectException
+from github.NamedUser import NamedUser
 
-@endpoint("/github/link", ["code"]) #Used for both linking, and updating
+user_to_token_table=User.table("user_to_token")
+@endpoint("/user_to_token/update", ["value", "column"]) #Used for linking, updating, and unlinking
 def link():
-    #Token must be a GitHub token with at least read access to public repositories 
+    #GitHub token must have at least read access to public repositories 
     #Assumes token is valid
-
-    User.table("user_to_token").upsert({"id": get_id_from_token(token), "token": code}).execute()
+    if value=="":
+        value=None
+    user_to_token_table.upsert({"id": get_id_from_token(token), column: value}).execute()
 
 #For internal use
-def _token(token):
-    lst=User.table("user_to_token").select("token").eq("id", get_id_from_token(token)).execute().data
+def retrieve(token, column):
+    lst=user_to_token_table.select(column).eq("id", get_id_from_token(token)).execute().data
     if len(lst)==0:
-        return ""
+        return None
     else:
-        return lst[0]["token"]
+        return lst[0][column]
 
 #Used solely for displaying the username in the settings page
-@endpoint("/github/token", [], ["code"])
-def view_token():
-    code=_token(token)
+@endpoint("/user_to_token/view", ["column"], ["value"])
+def view():
+    value=retrieve(token, column) or ""
 
-@endpoint("/github/unlink", []) #We *could* make it so that to unlink a token, you just send a blank "code" to /link
-def unlink():
-    User.table("user_to_token").delete().eq("id", get_id_from_token(token)).execute()
-    
+def get_github_user_from_token(token):
+    _token=retrieve(token, "github")
+    _username=None
+    if not _token:
+        _token=config["TEST_USER_GITHUB_TOKEN"]
+        _username=retrieve(token, "github_username")
+
+    return Github(auth=Auth.Token(_token)).get_user(_username)
+
 @endpoint("/github/projects/list", ["min_stars", "is_archived", "include", "exclude", "only"], ["repos"])
 def list():
     repos=[]
-    user=Github(auth=Auth.Token(_token(token))).get_user()
+
+    user=get_github_user_from_token(token)
+
+    _visibility="public"
+    if isinstance(user, NamedUser):
+        _visibility=None
 
     if min_stars is None:
         min_stars = 0
@@ -48,7 +61,7 @@ def list():
         repo_iterator=[user.get_repo(repo) for repo in repos]
     else:
         #We only care about public repos (what's the point of putting a repo in your resume that no one can see?)
-        repo_iterator=(repo for repo in user.get_repos(visibility="public", affiliation="owner") if ((repo.stargazers_count >= min_stars) and ((is_archived is None) or (repo.archived==is_archived)) and (repo.name not in exclude)) or (repo in include) ) #If "is_archived" is None, then accept repos regardless of archive status. Can add other filters later
+        repo_iterator=(repo for repo in user.get_repos(visibility=_visibility, affiliation="owner") if ((repo.stargazers_count >= min_stars) and ((is_archived is None) or (repo.archived==is_archived)) and (repo.name not in exclude)) or (repo in include) ) #If "is_archived" is None, then accept repos regardless of archive status. Can add other filters later
 
     for repo in repo_iterator:
         try: #Check if repository has readme
@@ -63,7 +76,7 @@ def _import():
 
     User.table("user_to_project").delete().eq("id", uid).execute() #Clear all projects associated with the user
 
-    user=Github(auth=Auth.Token(_token(token))).get_user()
+    user=get_github_user_from_token(token)
     
     data=[]
     for repo in repos:
@@ -90,8 +103,20 @@ def _import():
     User.table("user_to_project").insert(data).execute()
 
 @endpoint("/github/projects/view", [], ["repos"])
-def view():
+def view_projects():
     repos=User.table("user_to_project").select("name, url").eq("id", get_id_from_token(token)).execute().data
 
-#/github/selection --- stores json mapping between name of project an whether it was selected. ../get can be used to retrieve it, and set will be used to, well, set it.        
+#/github/selection --- stores JSON mapping between name of project and whether it was selected on the frontend during project import. /get can be used to retrieve it, and /set can be used to, well, set it.
+@endpoint("/github/selection/set", ["data"])
+def _set():
+    User.table("user_to_selection").upsert({"id": get_id_from_token(token), "data": data}).execute()
+
+@endpoint("/github/selection/get", [], ["data"])
+def _get():
+    data=User.table("user_to_selection").select("data").eq("id", get_id_from_token(token)).execute().data
+
+    if len(data)==0:
+        data={}
+    else:
+        data=data[0]["data"]
 

--- a/backend/github.py
+++ b/backend/github.py
@@ -2,6 +2,7 @@ from .utils import *
 from github import Github, Auth
 from github.GithubException import UnknownObjectException
 from github.NamedUser import NamedUser
+from github.GithubObject import NotSet
 
 user_to_token_table=User.table("user_to_token")
 @endpoint("/user_to_token/update", ["value", "column"]) #Used for linking, updating, and unlinking
@@ -27,7 +28,8 @@ def view():
 
 def get_github_user_from_token(token):
     _token=retrieve(token, "github")
-    _username=None
+
+    _username=NotSet
     if not _token:
         _token=config["TEST_USER_GITHUB_TOKEN"]
         _username=retrieve(token, "github_username")

--- a/backend/pdm.lock
+++ b/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:7de85e31d8faf450ce26ec8d9db9aa0e8255decc3edd0fb37bd08736b3509d55"
+content_hash = "sha256:670beca786a79e85f42c611003362a00ee679219c97a6ef01491abbb47f0b7a9"
 
 [[metadata.targets]]
 requires_python = "==3.11.*"
@@ -122,6 +122,17 @@ groups = ["default"]
 files = [
     {file = "blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc"},
     {file = "blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf"},
+]
+
+[[package]]
+name = "cachetools"
+version = "5.5.2"
+requires_python = ">=3.7"
+summary = "Extensible memoizing collections and decorators"
+groups = ["default"]
+files = [
+    {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
+    {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
 ]
 
 [[package]]
@@ -381,6 +392,42 @@ files = [
     {file = "frozenlist-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:0cc974cc93d32c42e7b0f6cf242a6bd941c57c61b618e78b6c0a96cb72788c1d"},
     {file = "frozenlist-1.5.0-py3-none-any.whl", hash = "sha256:d994863bba198a4a518b467bb971c56e1db3f180a25c6cf7bb1949c267f748c3"},
     {file = "frozenlist-1.5.0.tar.gz", hash = "sha256:81d5af29e61b9c8348e876d442253723928dce6433e0e76cd925cd83f1b4b817"},
+]
+
+[[package]]
+name = "google-auth"
+version = "2.38.0"
+requires_python = ">=3.7"
+summary = "Google Authentication Library"
+groups = ["default"]
+dependencies = [
+    "cachetools<6.0,>=2.0.0",
+    "pyasn1-modules>=0.2.1",
+    "rsa<5,>=3.1.4",
+]
+files = [
+    {file = "google_auth-2.38.0-py2.py3-none-any.whl", hash = "sha256:e7dae6694313f434a2727bf2906f27ad259bae090d7aa896590d86feec3d9d4a"},
+    {file = "google_auth-2.38.0.tar.gz", hash = "sha256:8285113607d3b80a3f1543b75962447ba8a09fe85783432a784fdeef6ac094c4"},
+]
+
+[[package]]
+name = "google-genai"
+version = "1.10.0"
+requires_python = ">=3.9"
+summary = "GenAI Python SDK"
+groups = ["default"]
+dependencies = [
+    "anyio<5.0.0,>=4.8.0",
+    "google-auth<3.0.0,>=2.14.1",
+    "httpx<1.0.0,>=0.28.1",
+    "pydantic<3.0.0,>=2.0.0",
+    "requests<3.0.0,>=2.28.1",
+    "typing-extensions<5.0.0,>=4.11.0",
+    "websockets<15.1.0,>=13.0.0",
+]
+files = [
+    {file = "google_genai-1.10.0-py3-none-any.whl", hash = "sha256:41b105a2fcf8a027fc45cc16694cd559b8cd1272eab7345ad58cfa2c353bf34f"},
+    {file = "google_genai-1.10.0.tar.gz", hash = "sha256:f59423e0f155dc66b7792c8a0e6724c75c72dc699d1eb7907d4d0006d4f6186f"},
 ]
 
 [[package]]
@@ -702,6 +749,31 @@ files = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.1"
+requires_python = ">=3.8"
+summary = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
+groups = ["default"]
+files = [
+    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
+    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+requires_python = ">=3.8"
+summary = "A collection of ASN.1-based protocols modules"
+groups = ["default"]
+dependencies = [
+    "pyasn1<0.7.0,>=0.6.1",
+]
+files = [
+    {file = "pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a"},
+    {file = "pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6"},
+]
+
+[[package]]
 name = "pycparser"
 version = "2.22"
 requires_python = ">=3.8"
@@ -914,6 +986,20 @@ dependencies = [
 files = [
     {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
     {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
+]
+
+[[package]]
+name = "rsa"
+version = "4.9"
+requires_python = ">=3.6,<4"
+summary = "Pure-Python RSA implementation"
+groups = ["default"]
+dependencies = [
+    "pyasn1>=0.1.3",
+]
+files = [
+    {file = "rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7"},
+    {file = "rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"},
 ]
 
 [[package]]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,7 +5,7 @@ description = "Default template for PDM package"
 authors = [
     {name = "DUOLabs333", email = "dvdugo333@gmail.com"},
 ]
-dependencies = ["supabase>=2.13.0", "flask>=3.1.0", "dotenv>=0.9.9", "pytest>=8.3.5", "pyjwt>=2.10.1", "requests>=2.32.3", "sqlalchemy>=2.0.39", "psycopg2-binary>=2.9.10", "pytest-cov>=6.0.0", "PyGithub>=2.6.1"]
+dependencies = ["supabase>=2.13.0", "flask>=3.1.0", "dotenv>=0.9.9", "pytest>=8.3.5", "pyjwt>=2.10.1", "requests>=2.32.3", "sqlalchemy>=2.0.39", "psycopg2-binary>=2.9.10", "pytest-cov>=6.0.0", "PyGithub>=2.6.1", "google-genai>=1.10.0"]
 requires-python = "==3.11.*"
 readme = "README.md"
 license = {text = "MIT"}

--- a/backend/tests/github.py
+++ b/backend/tests/github.py
@@ -4,6 +4,9 @@ email=config["TEST_USER_EMAIL"]
 password=config["TEST_USER_PASSWORD"]
 
 credentials={"email": email, "password": password} 
+
+columns=["github", "github_username"]
+
 def setup(client):
     global credentials
     client.post("/signup", json=credentials)
@@ -11,27 +14,22 @@ def setup(client):
 
     credentials={"token": token}
 
-def teardown(client):
-    ignore_asserts(test_unlink)(client)
+def test_update_and_view(client):
+    """
+    A. If a user tries to add or update a column in the user_to_token table, it should succeed.
 
-def test_link(client):
-    is_success(client.post("/github/link", json=credentials | {"code": config["TEST_USER_TOKEN"]}))
+    B. If a user tries to view the updated value(s), it should succeed.
+    """
+
+    for value in ["1", ""]:
+        for col in columns:
+            is_success(client.post("/user_to_token/update", json=credentials | {"role": col, "value": value}))
+            
+            assert is_success(client.post("/user_to_token/view", json=credentials | {"role": col}))["value"] == value
+
+    is_success(client.post("/user_to_token/update", json=credentials |{ "role": "github", "value": config["TEST_USER_GITHUB_TOKEN"]}))
 
     pass
-
-def test_token(client):
-    assert is_success(client.post("/github/token", json=credentials))["code"]==config["TEST_USER_TOKEN"]
-
-def test_link_update(client):
-    """
-    If a user tries to update their token, it should succeed
-    """
-
-    is_success(client.post("/github/link", json=credentials | {"code": "Testing123"}))
-
-    assert is_success(client.post("/github/token", json=credentials))["code"]=="Testing123"
-    
-    is_success(client.post("/github/link", json=credentials | {"code": config["TEST_USER_TOKEN"]}))
 
 repos=[]
 def test_list_projects(client):
@@ -65,14 +63,11 @@ def test_import_projects_invalid(client):
     for repos in [["kubernetes/kubernetes"], ["fhgidfgfudfb"]]:
         is_error(client.post("/github/projects/import", json=credentials| {"repos": repos}))
 
-def test_unlink(client):
-    is_success(client.post("/github/unlink", json=credentials))
-
-    pass
-
-def test_token_blank(client):
+def test_selection_set_and_get(client):
     """
-    If a user tries to view their token after unlinking it, they should get an empty string
+    A. If a user tries to set a selection dictionary, it should succeed.
+
+    B. If a user tries to retrieve the selection dictionary, it should succeed.
     """
 
-    assert is_success(client.post("/github/token", json=credentials))["code"]==""
+    data={"linux": True}

--- a/backend/tests/github.py
+++ b/backend/tests/github.py
@@ -23,11 +23,11 @@ def test_update_and_view(client):
 
     for value in ["1", ""]:
         for col in columns:
-            is_success(client.post("/user_to_token/update", json=credentials | {"role": col, "value": value}))
+            is_success(client.post("/user_to_token/update", json=credentials | {"column": col, "value": value}))
             
-            assert is_success(client.post("/user_to_token/view", json=credentials | {"role": col}))["value"] == value
+            assert is_success(client.post("/user_to_token/view", json=credentials | {"column": col}))["value"] == value
 
-    is_success(client.post("/user_to_token/update", json=credentials |{ "role": "github", "value": config["TEST_USER_GITHUB_TOKEN"]}))
+    is_success(client.post("/user_to_token/update", json=credentials |{ "column": "github", "value": config["TEST_USER_GITHUB_TOKEN"]}))
 
     pass
 

--- a/backend/tests/github.py
+++ b/backend/tests/github.py
@@ -5,8 +5,6 @@ password=config["TEST_USER_PASSWORD"]
 
 credentials={"email": email, "password": password} 
 
-columns=["github", "github_username"]
-
 def setup(client):
     global credentials
     client.post("/signup", json=credentials)
@@ -22,7 +20,7 @@ def test_update_and_view(client):
     """
 
     for value in ["1", ""]:
-        for col in columns:
+        for col in ["github", "github_username"]:
             is_success(client.post("/user_to_token/update", json=credentials | {"column": col, "value": value}))
             
             assert is_success(client.post("/user_to_token/view", json=credentials | {"column": col}))["value"] == value


### PR DESCRIPTION
This PR:
* Combines the various get/set/"forget"  endpoints for GitHub token, GitHub username into two --- `/user_to_project/update` and  `/user_to_project/view`
* Removes the requirement for users to provide their own GitHub and/or Gemini token (though other AI providers may come in the future), as we now provide our own token for general use (of course, if a user uses this token, the rate limit will be _much_ lower, but that is a risk they are knowingly taking).
* Added an embeddings column to the `user_to_project` table, while dropping everything else except `combined`, `name`, and `url`.
* Add get/set endpoints for keeping track of user selections on the frontend.

Closes #28 and #44.