### PR TITLE
Clarify installation instructions in backend README.md

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -3,10 +3,11 @@
 ## Contributor's Guide
 
 ### Installation
-_Note: This guide assumes that your CWD is in `backend`_
-1. Install `pdm`
-2. Run `pdm install` to install all of the necessary packages
-3. You're done!
+_Note: This guide assumes that your CWD is in `backend` (`cd backend`)_
+1. Install `pdm` (`pip install pdm`)
+2. Run `pdm install` to install all of the necessary packages 
+3. Activate backend environment (`.venv\Scripts\activate`)
+4. You're done!
 
 ### Running
 If you want to run the Flask server for development, run `pdm run flask run --debug`. Otherwise, just leave out the `--debug`.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,18 +1,167 @@
-# Backend
+# ResumeTailor Backend
 
-## Contributor's Guide
+## Overview
+
+Backend service for ResumeTailor providing user management, GitHub integration, and LaTeX resume management. Built with Flask and Supabase.
+
+## Features
+
+- User authentication and session management
+- GitHub repository integration with semantic search
+- Resume upload and management (.tex files)
+- Project analysis and embedding using Google's Gemini API
+- PostgreSQL database integration via Supabase
+
+## Setup
+
+### Prerequisites
+
+1. Python 3.11
+2. PDM package manager (`pip install pdm`)
+3. Supabase account
+4. Google Gemini API key
+5. GitHub API token (for development)
 
 ### Installation
-_Note: This guide assumes that your CWD is in `backend` (`cd backend`)_
-1. Install `pdm` (`pip install pdm`)
-2. Run `pdm install` to install all of the necessary packages 
-3. Activate backend environment (`.venv\Scripts\activate`)
-4. You're done!
 
-### Running
-If you want to run the Flask server for development, run `pdm run flask run --debug`. Otherwise, just leave out the `--debug`.
+```bash
+cd backend
+pip install pdm
+pdm config python.use_venv False
+pdm install
+```
+
+### Environment Configuration
+
+Create `.env` with:
+```
+# Supabase Configuration
+SUPABASE_URL=
+SUPABASE_USER_KEY=
+SUPABASE_ADMIN_KEY=
+SUPABASE_JWT_SECRET=
+
+# Database Configuration
+SUPABASE_PSQL_USER=
+SUPABASE_PSQL_PASSWORD=
+SUPABASE_PSQL_HOST=
+SUPABASE_PSQL_PORT=
+SUPABASE_PSQL_DBNAME=
+
+# Test Configuration
+TEST_USER_EMAIL=
+TEST_USER_PASSWORD=
+TEST_USER_GITHUB_TOKEN=
+TEST_USER_GEMINI_TOKEN=
+```
+
+## API Endpoints
+
+### Authentication (`users.py`)
+- `POST /signup`: Register new user
+  - Params: `email`, `password`
+- `POST /login`: User login
+  - Params: `email`, `password`
+  - Returns: `token`, `refresh_token`
+- `POST /refresh`: Refresh authentication token
+  - Params: `refresh_token`
+  - Returns: `token`, `refresh_token`
+- `POST /modify`: Update user details
+  - Params: Optional `email`, `password`
+  - Returns: Updated `email` if changed
+- `POST /logout`: Sign out user
+  - Params: `token`, Optional `scope` ("local"/"global")
+- `POST /delete`: Delete user account
+  - Requires valid token
+
+### GitHub Integration (`github.py`)
+- `POST /user_to_token/update`: Link GitHub account
+  - Params: `value`, `column`
+- `POST /github/projects/list`: List GitHub repositories
+  - Params: Optional `min_stars`, `is_archived`, `include[]`, `exclude[]`, `only[]`
+  - Returns: List of repos with URLs
+- `POST /github/projects/import`: Import selected projects
+  - Params: `repos[]` (list of repo names)
+  - Generates embeddings using Gemini API
+- `POST /github/selection/set`: Store project selection
+  - Params: `data` (selection state)
+- `GET /github/selection/get`: Retrieve project selection
+  - Returns: Selected projects data
+
+### Resume Management (`resume.py`)
+- `POST /resume/upload`: Upload LaTeX resume
+  - Params: `file` (.tex), Optional `update` (ID)
+  - Max file size: 5MB
+- `POST /resume/delete`: Delete resume
+  - Params: `id`
+- `POST /resume/list`: List user's resumes
+  - Returns: List of resumes with IDs and filenames
+- `POST /resume/rename`: Rename resume
+  - Params: `id`, `name` (must end in .tex)
+
+## Development
+
+### Running the Server
+
+```bash
+# Development with debug
+pdm run flask run --debug
+
+# Production mode
+pdm run flask run
+```
 
 ### Testing
 
-To run all of the tests, run `pdm run pytest`. If you don't want to generate coverage reports, run `pdm run pytest --no-cov` instead.
+```bash
+# Run all tests with coverage
+pdm run pytest
 
+# Run without coverage
+pdm run pytest --no-cov
+```
+
+### Key Files
+
+- `app.py`: Main application entry point
+- `users.py`: Authentication and user management
+- `github.py`: GitHub integration and project analysis
+- `resume.py`: Resume file management
+- `utils.py`: Shared utilities and endpoint decorators
+
+### Architecture Notes
+
+1. **Authentication Flow**
+   - JWT-based auth via Supabase
+   - Token refresh mechanism
+   - Support for both local and global logout
+
+2. **GitHub Integration**
+   - Repository filtering and analysis
+   - Semantic search using Gemini embeddings
+   - Project metadata extraction
+
+3. **Resume Management**
+   - LaTeX file validation
+   - Per-user resume storage
+   - File operations (upload, rename, delete)
+
+## Error Handling
+
+Common error types:
+- `StaleTokenError`: Authentication token expired
+- `ValueError`: Invalid input parameters
+- Database connection errors
+- File validation errors
+
+## Contributing
+
+1. Check issues and create feature branch
+2. Add tests for new functionality
+3. Ensure all tests pass: `pdm run pytest`
+4. Update documentation if needed
+5. Submit pull request
+
+## File Size Limits
+- Resume uploads: 5MB max
+- Review `app.config['MAX_CONTENT_LENGTH']` for current limits

--- a/backend/README.md
+++ b/backend/README.md
@@ -121,39 +121,6 @@ pdm run pytest
 pdm run pytest --no-cov
 ```
 
-### Key Files
-
-- `app.py`: Main application entry point
-- `users.py`: Authentication and user management
-- `github.py`: GitHub integration and project analysis
-- `resume.py`: Resume file management
-- `utils.py`: Shared utilities and endpoint decorators
-
-### Architecture Notes
-
-1. **Authentication Flow**
-   - JWT-based auth via Supabase
-   - Token refresh mechanism
-   - Support for both local and global logout
-
-2. **GitHub Integration**
-   - Repository filtering and analysis
-   - Semantic search using Gemini embeddings
-   - Project metadata extraction
-
-3. **Resume Management**
-   - LaTeX file validation
-   - Per-user resume storage
-   - File operations (upload, rename, delete)
-
-## Error Handling
-
-Common error types:
-- `StaleTokenError`: Authentication token expired
-- `ValueError`: Invalid input parameters
-- Database connection errors
-- File validation errors
-
 ## Contributing
 
 1. Check issues and create feature branch
@@ -161,7 +128,3 @@ Common error types:
 3. Ensure all tests pass: `pdm run pytest`
 4. Update documentation if needed
 5. Submit pull request
-
-## File Size Limits
-- Resume uploads: 5MB max
-- Review `app.config['MAX_CONTENT_LENGTH']` for current limits


### PR DESCRIPTION
#16 This pull request updates the `backend/README.md` file to improve the clarity and completeness of the installation instructions.

Documentation improvements:
* Clarified that the current working directory (CWD) should be in `backend` by explicitly including the command `cd backend`.
* Added the command `pip install pdm` to the instructions for installing `pdm`.
* Included a new step to activate the backend environment using `.venv\Scripts\activate`.